### PR TITLE
Fix missing run loop wraps

### DIFF
--- a/addon/components/hiding-menu.js
+++ b/addon/components/hiding-menu.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import layout from '../templates/components/hiding-menu';
 
-const {run, inject, $} = Ember;
+const { run, inject, $ } = Ember;
 
 export default Ember.Component.extend({
   layout,
@@ -29,7 +29,7 @@ export default Ember.Component.extend({
     let hidingScroll = this.get('hidingScroll');
     hidingScroll.off('scrollingUp', this, this.onScrollUp);
     hidingScroll.off('scrollingDown', this, this.onScrollDown);
-  }, 
+  },
 
   onScrollUp() {
     this.raf(() => this.showMenu());
@@ -40,13 +40,12 @@ export default Ember.Component.extend({
   },
 
   setupScrollMenuToggle(){
-    let $el = $(this.element);
-    let $menu = $el;
+    let $menu = this.$();
     let hidingScroll = this.get('hidingScroll');
 
     this.set('_menuHeight', this.get('menuHeight') || $menu.outerHeight());
 
-    if(parseInt(this.get('throttleTime')) === 150){
+    if (parseInt(this.get('throttleTime')) === 150) {
       hidingScroll.on('scrollingUp', this, this.onScrollUp);
       hidingScroll.on('scrollingDown', this, this.onScrollDown);
     } else {
@@ -56,18 +55,20 @@ export default Ember.Component.extend({
         });
       });
     }
-
   },
 
   raf(cb){
-    let fn = window.requestAnimationFrame || window.setTimeout;
-    fn(cb);
-  }, 
-  
+    if (window.requestAnimationFrame) {
+      window.requestAnimationFrame(run.bind(this, cb));
+    } else {
+      run.next(this, cb);
+    }
+  },
+
   onScroll(){
-    if(!this.get('isDestroyed')){
+    if (!this.get('isDestroyed')) {
       let newScrollTop = $('html').scrollTop() || $('body').scrollTop();
-      if(newScrollTop > this.get('bodyScrollTop')){
+      if (newScrollTop > this.get('bodyScrollTop')) {
         this.onScrollDown(newScrollTop);
       } else {
         this.onScrollUp();
@@ -79,12 +80,11 @@ export default Ember.Component.extend({
 
   hideMenu(newScrollTop){
     // check for Top Tollerance
-    if(newScrollTop > (document.body.scrollHeight - window.innerHeight - this.get('bottomTolerance') - this.get('_menuHeight'))){
-        this.set('isHidden', false);
-    } else if(!this.get('isHidden') && newScrollTop > this.get('_menuHeight') + this.get('topTolerance')){
-        this.set('isHidden', true);
+    if (newScrollTop > (document.body.scrollHeight - window.innerHeight - this.get('bottomTolerance') - this.get('_menuHeight'))) {
+      this.set('isHidden', false);
+    } else if (!this.get('isHidden') && newScrollTop > this.get('_menuHeight') + this.get('topTolerance')) {
+      this.set('isHidden', true);
     }
-
   },
 
   showMenu(){

--- a/addon/services/hiding-scroll.js
+++ b/addon/services/hiding-scroll.js
@@ -1,21 +1,23 @@
 import Ember from 'ember';
 
-const {$, run} = Ember;
+const { $, run } = Ember;
 
 export default Ember.Service.extend(Ember.Evented, {
 
-  init(){
+  init() {
     this._super(...arguments);
-    $(window).on('scroll.hiding-menu', () => {
-      this.trigger('scroll');
-      // run.throttle(this, this._onScroll, 20);
-      this._onScroll();
-    });
+    if (typeof FastBoot === 'undefined') {
+      $(window).on('scroll.hiding-menu', run.bind(this, function() {
+        this.trigger('scroll');
+        // run.throttle(this, this._onScroll, 20);
+        this._onScroll();
+      }));
+    }
   },
 
-  _onScroll(){
+  _onScroll() {
     let newScrollTop = $('html').scrollTop() || $('body').scrollTop();
-    if(newScrollTop > this.get('bodyScrollTop')){
+    if (newScrollTop > this.get('bodyScrollTop')) {
       this.trigger('scrollingDown', newScrollTop);
     } else {
       this.trigger('scrollingUp', newScrollTop);
@@ -26,6 +28,8 @@ export default Ember.Service.extend(Ember.Evented, {
 
   destroy() {
     this._super(...arguments);
-    $(window).off('scroll.hiding-menu');
+    if (typeof FastBoot === 'undefined') {
+      $(window).off('scroll.hiding-menu');
+    }
   },
 });

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -6,7 +6,7 @@ module.exports = function(defaults) {
   var app = new EmberAddon(defaults, {
     // Add options here
     vendorFiles: {
-      'jquery.js': null
+      // 'jquery.js': null
     }
   });
 

--- a/tests/dummy/app/app.js
+++ b/tests/dummy/app/app.js
@@ -10,14 +10,16 @@ Ember.Component.$ = $;
 Ember.__loader.require('ember-views/system/jquery').default = $;
 
 ['width', 'height'].forEach(function(dimension) {
-  var offset, Dimension = dimension.replace(/./, function(m) { return m[0].toUpperCase() });
+  var Dimension = dimension.replace(/./, function(m) { return m[0].toUpperCase(); });
   $.fn['outer' + Dimension] = function(margin) {
     var elem = this;
     if (elem) {
       var size = elem[dimension]();
       var sides = {'width': ['left', 'right'], 'height': ['top', 'bottom']};
       sides[dimension].forEach(function(side) {
-        if (margin) size += parseInt(elem.css('margin-' + side), 10);
+        if (margin) {
+          size += parseInt(elem.css('margin-' + side), 10);
+        }
       });
       return size;
     } else {


### PR DESCRIPTION
The latest version did not take care to wrap the event handlers/raf callbacks in an Ember run loop, leading to those errors I mentioned in #6 (only in tests).

Also in this PR:
* included jQuery again, so tests/dummy app can run (that only affects the addon itself, not your zepto based app, in case you wonder)
* fixed some jshint errors
* added FastBoot guards around browser code in the service

The acceptance test is still failing. Don't know if it ever worked? Cause I think in tests you would have to scroll the test container, not `<body>`. Also not sure what the magic in `app.js` is doing?