### PR TITLE
Fix calling set on destroyed object

### DIFF
--- a/addon/components/hiding-menu.js
+++ b/addon/components/hiding-menu.js
@@ -37,15 +37,19 @@ export default Ember.Component.extend({
   },
 
   onScrollUp() {
-    if (!this.get('isDestroyed')) {
-      this.raf(() => this.showMenu());
-    }
+    this.raf(() => {
+      if (!this.get('isDestroyed')) {
+        this.showMenu();
+      }
+    });
   },
 
   onScrollDown(newScrollTop) {
-    if (!this.get('isDestroyed')) {
-      this.raf(() => this.hideMenu(newScrollTop));
-    }
+    this.raf(() => {
+      if (!this.get('isDestroyed')) {
+        this.hideMenu(newScrollTop);
+      }
+    });
   },
 
   setMenuHeight() {


### PR DESCRIPTION
I encountered errors in tests. The `raf` callback can be executed when the component has already been destroyed, so I moved the `isDestroyed` guard inside of the callback.